### PR TITLE
Fix a performance bug

### DIFF
--- a/Clique.py
+++ b/Clique.py
@@ -58,14 +58,14 @@ def get_dense_units_for_dim(data, prev_dim_dense_units, dim, xsi, tau):
 
     # Count number of elements in candidates
     projection = np.zeros(len(candidates))
-    number_of_data_points = np.shape(data)[0]
-    for dataIndex in range(number_of_data_points):
-        for i in range(len(candidates)):
-            if is_data_in_projection(data[dataIndex], candidates[i], xsi):
+    for data_point in data:
+        for i, candidate in enumerate(candidates):
+            if is_data_in_projection(data_point, candidate, xsi):
                 projection[i] += 1
     print("projection: ", projection)
 
     # Return elements above density threshold
+    number_of_data_points = np.shape(data)[0]
     is_dense = projection > tau * number_of_data_points
     print("is_dense: ", is_dense)
     return np.array(candidates)[is_dense]


### PR DESCRIPTION
Don't repeatedly access the same element in the inner loop.

Profiling with `cProfile` shows that `is_data_in_projection` is called frequently (4500 times for `mouse.csv` with default parameters).
This means that `data[dataIndex]` would be accessed in _every_ call to `is_data_in_projection`, even if only the candidate changed.
It should be clear that this can potentially be very expensive: In the worst case, we'd cache miss every access to the `data` array.
It's better to simply save the data element in a local variable so we don't have to make an array lookup up every time we try a new candidate.

The performance benefit is not obvious when using `mouse.csv`.
However, I used this library a while back in [a work project ](https://gitlab.com/gregor_ulm/fcc_raster/-/tree/master/1_benchmark_sklearn_clique) with a much larger data file and this change gave a significant speedup. 

There aren't many implementations of CLIQUE available, so I think merging this PR is worthwhile.